### PR TITLE
Nested directories and keeping generated files.

### DIFF
--- a/galleries.rb
+++ b/galleries.rb
@@ -12,7 +12,18 @@ require "RMagick"
 
 module Jekyll
 
-
+     # This part is copied from https://github.com/kinnetica/jekyll-plugins
+     # Without it, generation does fail. --dmytro
+	 # Recover from strange exception when starting server without --auto
+	 class GalleryFile < StaticFile
+	 	def write(dest)
+	 		begin
+               super(dest)
+	 	    rescue
+	 	    end
+            true
+	 	end
+	 end
 
 	 class GalleryTag < Liquid::Block
 
@@ -125,7 +136,7 @@ module Jekyll
 	 				name = File.basename(file).sub(File.extname(file), "-thumb#{File.extname(file)}")
 	 				thumbname = File.join(@gallery_dest, name)
                     # Keep the thumb files from being cleaned by Jekyll
-                    site.static_files << Jekyll::SitemapFile.new(site, site.dest, @config['dir'], name )
+                    site.static_files << Jekyll::GalleryFile.new(site, site.dest, @config['dir'], name )
 	 				if !File.exists?(thumbname)
 	 					to_resize.push({ "file" => file, "thumbname" => thumbname })
 	 				end


### PR DESCRIPTION
Two changes include in the pull request:
1. Add *\* in Dir.glob for allowing nested subdirectories in galleries. In the gallery tag need to specify sub-path of the images as in:

```
{% gallery new_gallery %}
new_gallery/IMG_1738.jpg:: Comment
new_gallery/IMG_1739.jpg:: Comment
{% endgallery %}
```
1. Keep generated thumbnail files from overwriting.

When plugin is used to generate content in `_site` subdirectory, then all generated file *-thumb.jpg are deleted right after generation. Adding them to `site.static_files` prevent form cleaning.
